### PR TITLE
Fix dependencies order

### DIFF
--- a/LLO-regnskabWeb/aurelia_project/aurelia.json
+++ b/LLO-regnskabWeb/aurelia_project/aurelia.json
@@ -96,7 +96,6 @@
       {
         "name": "vendor-bundle.js",
         "prepend": [
-          "node_modules/jquery/dist/jquery.js",
           "node_modules/bluebird/js/browser/bluebird.core.js",
           "node_modules/aurelia-cli/lib/resources/scripts/configure-bluebird.js",
           "node_modules/requirejs/require.js"
@@ -145,6 +144,8 @@
             "main": "aurelia-fetch-client",
             "path": "../node_modules/aurelia-fetch-client/dist/amd"
           },
+          "jquery",
+          "tslib",
           {
             "name": "materialize-amd",
             "path": "../node_modules/materialize-amd/dist",
@@ -165,8 +166,6 @@
               "**/*.{css,html}"
             ]
           },
-          "jquery",
-          "tslib",
           {
             "name": "moment",
             "main": "./moment.js",


### PR DESCRIPTION
The dependencies order matters. Plus, for 0.32.0 prepend is not needed.